### PR TITLE
Updating short open tag to normal opening tag

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -75,7 +75,7 @@ function pmproga4_load_script() {
             {
                 'currency': '<?php echo get_option( "pmpro_currency" ); ?>',
                 <?php if ( is_user_logged_in() ) { ?>
-                'user_id': '<? echo get_current_user_id(); ?>',
+                'user_id': '<?php echo get_current_user_id(); ?>',
                 <?php } ?>
                 <?php if ( ! empty( $custom_dimensions ) ) { 
                     foreach ( $custom_dimensions as $key => $value ) { ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-google-analytics/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-google-analytics/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The string `<? echo get_current_user_id(); ?>` is sent to Google Analytics instead of the user ID on PHP environments where the short open tag is disabled/removed. 

This breaks Google Analytics tracking for logged-in users.

Using the normal opening tag resolves this.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Using normal PHP opening tag instead of short open tag
