### PR TITLE
Bug if level is null

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -208,6 +208,11 @@ function pmproga4_view_item_event( $track_levels = null ) {
 function pmproga4_checkout_events() {
     global $pmpro_level;
 
+	// Bail if level is not set.
+	if( !isset( $pmpro_level ) ) {
+		return;
+	}
+
     // Only run this on the checkout page.
     if ( ! pmpro_is_checkout() ) {
         return;


### PR DESCRIPTION
 * Bail if global $pmpro-level is null.
![image](https://github.com/strangerstudios/pmpro-google-analytics/assets/1678457/49035664-a16a-485b-b99a-41fd4784b66d)

<img width="1236" alt="image" src="https://github.com/strangerstudios/pmpro-google-analytics/assets/1678457/a1e14c55-3cd1-452d-a297-5b5d615582d1">


### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-google-analytics/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-google-analytics/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

Enable this plugin
Navigate to the memberships-account page.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
