### PR TITLE
Logic to support admin refunds.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -114,6 +114,165 @@ function pmproga4_show_setup_notice() {
 add_action( 'admin_notices', 'pmproga4_show_setup_notice' );
 
 /**
+ * Load the Google Analytics script on the admin pages.
+ *
+ * @since TBD
+ */
+function pmproga4_load_admin_script() {
+
+    // Only run this if PMPro is installed.
+    if ( ! defined( 'PMPRO_VERSION' ) ) {
+        return;
+    }
+
+    // Only show on PMPro admin pages.
+	if ( empty( $_REQUEST['page'] ) || strpos( $_REQUEST['page'], 'pmpro' ) === false ) {
+		return;
+	}
+
+    extract( $pmproga4_settings = get_option( 'pmproga4_settings',
+        array(
+            'measurement_id'       => '',
+            'track_levels'      => array()
+        )
+    ) );
+
+    /**
+     * Determines whether to halt tracking based on specific conditions.
+     *
+     * This filter provides an opportunity for developers to stop tracking for specific 
+     * scenarios, such as based on user ID, post, custom roles, etc. If the filter returns
+     * `true`, tracking will be halted.
+     *
+     * @since 1.0
+     *
+     * @param bool $stop_tracking Default value is `false`. If set to `true` by any filter, tracking will be halted.
+     *
+     * @return void
+     */
+    if ( apply_filters( 'pmproga4_dont_track', false ) ) {
+        return;
+    }
+
+    // No measurement ID found, let's bail.
+    if ( empty( $measurement_id ) ) {
+        return;
+    }
+
+    /**
+     * Filters the attributes applied to the Google Analytics script tag loaded in wp_admin.
+     *
+     * Allows developers to customize or add specific attributes to the Google Analytics script tag
+     * for enhanced control or additional features.
+     *
+     * @since 1.0
+     *
+     * @param string $script_atts Default value is an empty string. Contains attributes for the GA script tag.
+     *
+     * @return string Modified attributes for the GA admin script tag.
+     */
+    $script_atts = apply_filters( 'pmproga4_admin_script_atts', '' );
+
+    ?>
+    <!-- Paid Memberships Pro - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_attr( $measurement_id ); ?>"></script>
+    <script <?php echo esc_attr($script_atts); ?>>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 
+            '<?php echo esc_attr( $measurement_id ); ?>',
+            {
+                'currency': '<?php echo get_option( "pmpro_currency" ); ?>',
+                'send_page_view': false,
+            }
+        );
+	</script>
+    <?php
+
+}
+add_action( 'admin_enqueue_scripts', 'pmproga4_load_admin_script' );
+
+/**
+ * Load the pmproga4_refund_event function on the pmpro_updated_order hook if status is refunded.
+ *
+ * @since TBD
+ */
+function pmproga4_refund_event_on_order_status_refunded( $pmpro_invoice, $original_status ) {
+    // Prevent unnecessary data sent to GA4 by only running this if the order wasn't already in refund status.
+    if ( 'refunded' != $original_status ) {
+        pmproga4_refund_event( $pmpro_invoice );
+    }
+}
+add_action( 'pmpro_order_status_refunded', 'pmproga4_refund_event_on_order_status_refunded', 10, 2 );
+
+/**
+ * Enqueue the Google Analytics script for a refunded order.
+ *
+ * @since TBD
+ */
+function pmproga4_load_admin_order_refunded_script( $pmpro_invoice ) {
+    pmproga4_refund_event( $pmpro_invoice );
+}
+
+/**
+ * Function for refund event.
+ */
+function pmproga4_refund_event( $pmpro_invoice ) {
+
+    // Set the ecommerce dataLayer script if the order ID matches the session variable.
+    if ( ! empty( $pmpro_invoice ) && ! empty( $pmpro_invoice->id ) ) {
+        $pmpro_invoice->getMembershipLevel();
+
+        // Set the ecommerce dataLayer script.
+        $gtag_config_ecommerce_data = array();
+        $gtag_config_ecommerce_data['transaction_id'] = $pmpro_invoice->code;
+        $gtag_config_ecommerce_data['value'] = $pmpro_invoice->membership_level->initial_payment;
+        
+        if ( ! empty( $pmpro_invoice->tax ) ) {
+            $gtag_config_ecommerce_data['tax'] = $pmpro_invoice->tax;
+        } else {
+            $gtag_config_ecommerce_data['tax'] = 0;
+        }
+
+        if ( $pmpro_invoice->getDiscountCode() ) {
+            $gtag_config_ecommerce_data['coupon'] = $pmpro_invoice->discount_code->code;
+        } else {
+            $gtag_config_ecommerce_data['coupon'] = '';
+        }
+
+        // Build an array of product data.
+        $gtag_config_ecommerce_products = array();
+        $gtag_config_ecommerce_products['item_id'] = $pmpro_invoice->membership_level->id;
+        $gtag_config_ecommerce_products['item_name'] = $pmpro_invoice->membership_level->name;
+        $gtag_config_ecommerce_products['affiliation'] = get_bloginfo( 'name' );
+        if ( $pmpro_invoice->getDiscountCode() ) {
+            $gtag_config_ecommerce_products['coupon'] = $pmpro_invoice->discount_code->code;
+        }
+        $gtag_config_ecommerce_products['index'] = 0;
+        $gtag_config_ecommerce_products['price'] = $pmpro_invoice->membership_level->initial_payment;
+        $gtag_config_ecommerce_products['quantity'] = 1;
+        ?>
+        <script>
+            jQuery(document).ready(function() {
+                gtag( 'event', 'refund', {
+                    transaction_id: '<?php echo $gtag_config_ecommerce_data['transaction_id']; ?>',
+                    value: <?php echo $gtag_config_ecommerce_data['value']; ?>,
+                <?php if ( ! empty( $gtag_config_ecommerce_data['tax'] ) ) { ?>
+                    tax: <?php echo $gtag_config_ecommerce_data['tax']; ?>,
+                    <?php } ?>
+                    <?php if( ! empty( $gtag_config_ecommerce_data['coupon'] ) ) { ?>
+                    coupon: '<?php echo $gtag_config_ecommerce_data['coupon']; ?>',
+                    <?php } ?>
+                    items: [ <?php echo json_encode( $gtag_config_ecommerce_products ); ?> ]
+                });
+            });
+        </script>
+        <?php
+    }
+}
+
+/**
  * Add a link to the settings page to the plugin action links.
  */
 function pmproga4_plugin_action_links( $links ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-google-analytics/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-google-analytics/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now loading our Google Analytics code in the WordPress admin on PMPro pages when orders are updated. Could use further testing, for example, when the order comes in from the gateway. This is hard to test with the GA4 testing tool. I did process a few so my dev site will be able to see this tomorrow potentially.

Let's also consider if we should or should not offer a feature to disable refund tracking.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* FEATURE: Added event tracking for order refunds.
