### PR TITLE
Update pmproga_plugin_row_meta function prefix to resolve Gift Aid conflict

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -141,7 +141,7 @@ add_filter( 'plugin_action_links_' . PMPROGA_BASENAME, 'pmproga4_plugin_action_l
  * @param array  $links Array of links to be shown in plugin meta.
  * @param string $file Filename of the plugin meta is being shown for.
  */
-function pmproga_plugin_row_meta( $links, $file ) {
+function pmproga4_plugin_row_meta( $links, $file ) {
 	if ( strpos( $file, 'pmpro-google-analytics.php' ) !== false ) {
 		$new_links = array(
 			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/google-analytics/' ) . '" title="' . esc_attr__( 'View Documentation', 'pmpro-google-analytics' ) . '">' . esc_html__( 'Docs', 'pmpro-google-analytics' ) . '</a>',
@@ -151,4 +151,4 @@ function pmproga_plugin_row_meta( $links, $file ) {
 	}
 	return $links;
 }
-add_filter( 'plugin_row_meta', 'pmproga_plugin_row_meta', 10, 2 );
+add_filter( 'plugin_row_meta', 'pmproga4_plugin_row_meta', 10, 2 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-google-analytics/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-google-analytics/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updating the function prefix from `pmproga` (used by Gift Aid Add On) to `pmproga4`.

Resolves a fatal error (`Cannot redeclare pmproga_plugin_row_meta()`) that occurs when trying to activate both Gift Aid and Google Analytics Add Ons on a site.

### How to test the changes in this Pull Request:
1. Install Gift Aid and Google Analytics Add Ons.
2. Try activating both Add Ons.
3. See error.
4. Apply PR.
5. Try activating both Add Ons.

### Other information:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->