### PR TITLE
Fix issue with author dimension causing infinite loop

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -385,10 +385,11 @@ function pmproga4_custom_dimensions() {
     if ( isset( $gtag_config_custom_dimensions['author'] ) ) {
         $author = '';
         if ( is_singular() ) {
-            if ( have_posts() ) {
-                while ( have_posts() ) {
-                    the_post();
-                    $author = get_the_author_meta( 'display_name' );
+            $post_id = get_the_ID();
+            if ( $post_id ) {
+                $author_id = get_post_field( 'post_author', $post_id );
+                if ( $author_id ) {
+                    $author = get_the_author_meta( 'display_name', $author_id );
                 }
             }
         }


### PR DESCRIPTION
* BUG FIX: Fixes an issue where some plugins may interfere with our loop for getting the author. Moved this to a single check to get the author of the specific post ID to resolve the issue.

Resolves: #5

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-google-analytics/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-google-analytics/pulls/) for the same update/change?
