### PR TITLE
BUG FIX: Add null check for $pmpro_level in checkout events

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -213,6 +213,11 @@ function pmproga4_checkout_events() {
         return;
     }
 
+    // Bail if the membership level is not set.
+    if ( empty( $pmpro_level ) ) {
+        return;
+    }
+
     // Build an array of product data.
     $gtag_config_ecommerce_products = array();
     $gtag_config_ecommerce_products['item_id'] = $pmpro_level->id;


### PR DESCRIPTION
## Description

Adds a null check for the global `$pmpro_level` variable in `pmproga4_checkout_events()` to prevent fatal errors when the membership level is not set.

## The Bug

`pmproga4_checkout_events()` runs on checkout page load and immediately accesses `$pmpro_level->id`, `$pmpro_level->name`, and `$pmpro_level->initial_payment` without checking if the global is set. This causes a fatal error (or PHP warnings/notices) when `$pmpro_level` is null — which can happen in edge cases like direct page access or when another plugin interferes with the checkout flow.

## The Fix

Added an early return when `$pmpro_level` is empty, following the same guard pattern already used in the function for `pmpro_is_checkout()`:

```php
// Bail if the membership level is not set.
if ( empty( $pmpro_level ) ) {
    return;
}
```

## Testing

1. Visit the PMPro checkout page normally with a level selected — GA4 events should still fire.
2. Visit the checkout page without a level parameter — should no longer produce errors.